### PR TITLE
Add initial repository file tests

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+def test_readme_ends_with_newline():
+    with open('README.md', 'rb') as f:
+        content = f.read()
+    assert content.endswith(b"\n"), "README.md should end with a newline"
+
+
+def test_license_has_no_placeholder():
+    with open('LICENSE', 'r', encoding='utf-8') as f:
+        text = f.read()
+    assert '[yyyy]' not in text, "LICENSE should not contain the '[yyyy]' placeholder"
+


### PR DESCRIPTION
## Summary
- add `tests` directory with a `pytest` test suite
- check README ends with a newline
- ensure `LICENSE` does not use the `[yyyy]` placeholder

## Testing
- `pytest -q` *(fails: README lacks trailing newline, LICENSE contains placeholder)*