### PR TITLE
refactor: replace custom styles with tailwind

### DIFF
--- a/src/components/CaptureControls.jsx
+++ b/src/components/CaptureControls.jsx
@@ -13,15 +13,19 @@ export default function CaptureControls({
   }
 
   return (
-    <div className="controls">
+    <div className="flex flex-col space-y-4">
       {capturing ? (
-        <button onClick={onStop}>화면 공유 중지</button>
+        <button onClick={onStop} className="px-4 py-2 bg-red-500 text-white rounded">
+          화면 공유 중지
+        </button>
       ) : (
-        <button onClick={onStart}>화면 공유 시작</button>
+        <button onClick={onStart} className="px-4 py-2 bg-blue-500 text-white rounded">
+          화면 공유 시작
+        </button>
       )}
-      <div className="slider">
-        <label>
-          OCR 주기(ms): {interval}
+      <div className="flex flex-col space-y-2">
+        <label className="flex flex-col">
+          <span>OCR 주기(ms): {interval}</span>
           <input
             type="range"
             min="500"
@@ -29,14 +33,24 @@ export default function CaptureControls({
             step="500"
             value={interval}
             onChange={(e) => setIntervalMs(Number(e.target.value))}
+            className="mt-1"
           />
         </label>
       </div>
-      <div className="roi-sliders">
+      <div className="grid grid-cols-2 gap-2">
         {['x', 'y', 'w', 'h'].map((k) => (
-          <label key={k}>
-            {k.toUpperCase()}: {roi[k]}
-            <input type="range" min="0" max="800" value={roi[k]} onChange={handleRoi(k)} />
+          <label key={k} className="flex flex-col">
+            <span>
+              {k.toUpperCase()}: {roi[k]}
+            </span>
+            <input
+              type="range"
+              min="0"
+              max="800"
+              value={roi[k]}
+              onChange={handleRoi(k)}
+              className="mt-1"
+            />
           </label>
         ))}
       </div>

--- a/src/components/ChartView.jsx
+++ b/src/components/ChartView.jsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 export default function ChartView({ data }) {
   const chartData = data.map((d) => ({ ...d, timeLabel: dayjs(d.time).format('HH:mm:ss') }))
   return (
-    <div className="chart">
+    <div className="w-full h-72">
       <ResponsiveContainer width="100%" height={300}>
         <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -2,9 +2,9 @@ import dayjs from 'dayjs'
 
 export default function Timeline({ results }) {
   return (
-    <ul className="timeline">
+    <ul className="max-h-52 overflow-y-auto bg-white border border-gray-300 rounded p-2 space-y-1 text-sm">
       {[...results].reverse().map((r, i) => (
-        <li key={i}>
+        <li key={i} className="p-1 border-b last:border-b-0">
           {dayjs(r.time).format('HH:mm:ss')} - {r.value}
         </li>
       ))}

--- a/src/components/VideoCanvas.jsx
+++ b/src/components/VideoCanvas.jsx
@@ -47,9 +47,9 @@ const VideoCanvas = forwardRef(({ stream, roi, overlayRef, onMouseDown }, ref) =
   }))
 
   return (
-    <div className="video-container">
-      <video ref={videoRef} className="video" autoPlay playsInline />
-      <canvas ref={overlayRef} className="overlay" onMouseDown={onMouseDown} />
+    <div className="relative inline-block">
+      <video ref={videoRef} className="block max-w-full" autoPlay playsInline />
+      <canvas ref={overlayRef} className="absolute top-0 left-0" onMouseDown={onMouseDown} />
     </div>
   )
 })


### PR DESCRIPTION
## Summary
- refactor capture controls to use Tailwind for layout and buttons
- restyle timeline, chart, and video canvas with Tailwind utilities
- drop bespoke CSS classes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6894a1672f8483229eabea6128251fa0