### PR TITLE
Preserve OCR results and allow manual clearing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,10 @@ export default function App() {
   const [intervalMs, setIntervalMs] = useState<number>(1000)
   const [results, setResults] = useState<OcrResult[]>([])
 
+  const handleClearResults = () => {
+    setResults([])
+  }
+
   useEffect(() => {
     if (!stream) return
 
@@ -50,12 +54,6 @@ export default function App() {
     }
   }, [intervalMs, recognize, stream])
 
-  useEffect(() => {
-    if (!stream) {
-      setResults([])
-    }
-  }, [stream])
-
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto space-y-6 px-4 py-8">
@@ -77,7 +75,7 @@ export default function App() {
               roi={roi}
               setRoi={setRoi}
             />
-            <Timeline results={results} />
+            <Timeline results={results} onClear={handleClearResults} />
           </div>
 
           <div className="space-y-6">

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,19 +1,24 @@
 import dayjs from 'dayjs'
 
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { OcrResult } from '@/types/capture'
 
 interface TimelineProps {
   results: OcrResult[]
+  onClear: () => void
 }
 
-export default function Timeline({ results }: TimelineProps) {
+export default function Timeline({ results, onClear }: TimelineProps) {
   const hasResults = results.length > 0
 
   return (
     <Card className="h-full">
-      <CardHeader>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
         <CardTitle>인식 결과 타임라인</CardTitle>
+        <Button variant="outline" size="sm" onClick={onClear} disabled={!hasResults}>
+          데이터 초기화
+        </Button>
       </CardHeader>
       <CardContent>
         {hasResults ? (


### PR DESCRIPTION
## Summary
- keep OCR results available after screen sharing stops so collected data is preserved
- add a clear button to the timeline card so users can clean the saved data when desired

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cd7f0a9d9c8322a723acd263236902