### PR TITLE
Ensure layout fits within viewport height

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,49 +57,53 @@ export default function App() {
   }, [stream])
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto space-y-6 px-4 py-8">
-        <header className="space-y-2 text-center">
+    <div className="flex h-dvh flex-col bg-background">
+      <header className="border-b border-border/60">
+        <div className="container mx-auto space-y-2 px-4 py-8 text-center">
           <h1 className="text-3xl font-semibold tracking-tight">Maple Recorder</h1>
           <p className="text-sm text-muted-foreground">
             화면 공유를 통해 특정 영역의 텍스트를 주기적으로 추출하고 결과를 타임라인과 차트로 확인하세요.
           </p>
-        </header>
+        </div>
+      </header>
 
-        <div className="grid gap-6 lg:grid-cols-[320px,1fr]">
-          <div className="space-y-6">
-            <CaptureControls
-              capturing={Boolean(stream)}
-              onStart={startCapture}
-              onStop={stopCapture}
-              interval={intervalMs}
-              setIntervalMs={setIntervalMs}
-              roi={roi}
-              setRoi={setRoi}
-            />
-            <Timeline results={results} />
-          </div>
+      <main className="flex-1 overflow-y-auto">
+        <div className="container mx-auto px-4 py-8">
+          <div className="grid gap-6 lg:grid-cols-[320px,1fr]">
+            <div className="space-y-6">
+              <CaptureControls
+                capturing={Boolean(stream)}
+                onStart={startCapture}
+                onStop={stopCapture}
+                interval={intervalMs}
+                setIntervalMs={setIntervalMs}
+                roi={roi}
+                setRoi={setRoi}
+              />
+              <Timeline results={results} />
+            </div>
 
-          <div className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>실시간 화면 미리보기</CardTitle>
-                <CardDescription>선택한 영역이 붉은 사각형으로 표시됩니다.</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <VideoCanvas
-                  ref={videoRef}
-                  stream={stream}
-                  roi={roi}
-                  overlayRef={overlayRef}
-                  onMouseDown={onMouseDown}
-                />
-              </CardContent>
-            </Card>
-            <ChartView data={results} />
+            <div className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>실시간 화면 미리보기</CardTitle>
+                  <CardDescription>선택한 영역이 붉은 사각형으로 표시됩니다.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <VideoCanvas
+                    ref={videoRef}
+                    stream={stream}
+                    roi={roi}
+                    overlayRef={overlayRef}
+                    onMouseDown={onMouseDown}
+                  />
+                </CardContent>
+              </Card>
+              <ChartView data={results} />
+            </div>
           </div>
         </div>
-      </div>
+      </main>
     </div>
   )
 }

--- a/src/components/CaptureControls.tsx
+++ b/src/components/CaptureControls.tsx
@@ -38,7 +38,7 @@ export default function CaptureControls({
   }
 
   return (
-    <Card className="h-full">
+    <Card>
       <CardHeader>
         <CardTitle>화면 캡처 제어</CardTitle>
         <CardDescription>화면 공유와 OCR 주기를 관리하세요.</CardDescription>

--- a/src/components/ChartView.tsx
+++ b/src/components/ChartView.tsx
@@ -39,7 +39,7 @@ export default function ChartView({ data }: ChartViewProps) {
     .filter((point): point is ChartDataPoint => point !== null)
 
   return (
-    <Card className="h-full">
+    <Card>
       <CardHeader>
         <CardTitle>수치 변화 차트</CardTitle>
         <CardDescription>숫자로 인식된 값만 추려서 시계열로 표시합니다.</CardDescription>

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -11,7 +11,7 @@ export default function Timeline({ results }: TimelineProps) {
   const hasResults = results.length > 0
 
   return (
-    <Card className="h-full">
+    <Card>
       <CardHeader>
         <CardTitle>인식 결과 타임라인</CardTitle>
       </CardHeader>

--- a/src/index.css
+++ b/src/index.css
@@ -62,7 +62,16 @@
   * {
     @apply border-border;
   }
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
   body {
     @apply bg-background text-foreground;
+    overflow: hidden;
+  }
+  .notice {
+    @apply fixed left-1/2 bottom-4 w-full max-w-xl -translate-x-1/2 px-4 text-center text-xs text-muted-foreground;
   }
 }


### PR DESCRIPTION
## Summary
- restructure the app layout to pin the header and place the main content inside a scrollable viewport-height container
- adjust card components and global styles so stacked panels size to their content and the legal notice floats without affecting layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cd7eceb5a483228c7f7f3b341434fe