### PR TITLE
Relocate local data notice to capture controls card

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <p class="notice">모든 OCR·캡처 데이터는 로컬에서만 처리되며 서버로 전송되지 않습니다.</p>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/CaptureControls.tsx
+++ b/src/components/CaptureControls.tsx
@@ -96,6 +96,10 @@ export default function CaptureControls({
             ))}
           </div>
         </div>
+
+        <div className="rounded-lg border border-muted bg-muted/40 p-4 text-xs leading-relaxed text-muted-foreground">
+          모든 OCR·캡처 데이터는 로컬에서만 처리되며 서버로 전송되지 않습니다.
+        </div>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary
- remove the out-of-place local data processing notice from the HTML shell
- surface the privacy notice inside the capture controls card with supportive styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cd7fd821dc8322aab8a2c7e8780cac